### PR TITLE
設定画面を作成し、RSS URL を変更可能にする

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,14 @@
 {
   "permissions": {
     "allow": [
-      "Bash(xcodebuild:*)"
+      "Bash(xcodebuild:*)",
+      "Bash(gh issue view:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr checks:*)"
     ],
     "deny": []
   }

--- a/QuickFeed/MenuView.swift
+++ b/QuickFeed/MenuView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 /// メニューバーのドロップダウンメニューを表示するビュー
 struct MenuView: View {
     @EnvironmentObject var feedManager: RSSFeedManager
-    @State private var showingSettings = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -24,7 +23,7 @@ struct MenuView: View {
                 
                 // 設定ボタン
                 Button(action: {
-                    showingSettings = true
+                    openSettingsWindow()
                 }) {
                     Image(systemName: "gearshape")
                         .foregroundColor(.secondary)
@@ -117,10 +116,24 @@ struct MenuView: View {
             .padding(.vertical, 6)
         }
         .frame(width: 360)
-        .sheet(isPresented: $showingSettings) {
-            SettingsView()
-                .environmentObject(feedManager)
-        }
+    }
+    
+    private func openSettingsWindow() {
+        let settingsView = SettingsView()
+            .environmentObject(feedManager)
+        
+        let hostingController = NSHostingController(rootView: settingsView)
+        let window = NSWindow(contentViewController: hostingController)
+        
+        window.title = "QuickFeed 設定"
+        window.setContentSize(NSSize(width: 400, height: 200))
+        window.styleMask = [.titled, .closable]
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        
+        // ウィンドウを最前面に表示
+        NSApp.activate(ignoringOtherApps: true)
     }
     
     private func formatLastUpdate() -> String {

--- a/QuickFeed/MenuView.swift
+++ b/QuickFeed/MenuView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// メニューバーのドロップダウンメニューを表示するビュー
 struct MenuView: View {
     @EnvironmentObject var feedManager: RSSFeedManager
+    @State private var showingSettings = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -20,6 +21,16 @@ struct MenuView: View {
                 Text("QuickFeed")
                     .font(.headline)
                 Spacer()
+                
+                // 設定ボタン
+                Button(action: {
+                    showingSettings = true
+                }) {
+                    Image(systemName: "gearshape")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("設定")
                 
                 // 更新ボタン
                 Button(action: {
@@ -106,6 +117,10 @@ struct MenuView: View {
             .padding(.vertical, 6)
         }
         .frame(width: 360)
+        .sheet(isPresented: $showingSettings) {
+            SettingsView()
+                .environmentObject(feedManager)
+        }
     }
     
     private func formatLastUpdate() -> String {

--- a/QuickFeed/RSSFeedManager.swift
+++ b/QuickFeed/RSSFeedManager.swift
@@ -16,9 +16,20 @@ class RSSFeedManager: ObservableObject {
     @Published var isLoading = false
     @Published var errorMessage: String?
     
-    private let feedURL = "https://softantenna.com/folders/feed.rss"
+    private let defaultFeedURL = "https://softantenna.com/folders/feed.rss"
+    private let feedURLKey = "RSSFeedURL"
     private let parser = RSSParser()
     private var timer: Timer?
+    
+    /// 現在設定されているRSSフィードのURL
+    var feedURL: String {
+        get {
+            UserDefaults.standard.string(forKey: feedURLKey) ?? defaultFeedURL
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: feedURLKey)
+        }
+    }
     
     init() {
         // アプリ起動時にフィードを取得
@@ -74,6 +85,12 @@ class RSSFeedManager: ObservableObject {
     private func stopAutoUpdate() {
         timer?.invalidate()
         timer = nil
+    }
+    
+    /// RSSフィードのURLを更新し、新しいフィードを取得する
+    func updateFeedURL(_ newURL: String) {
+        feedURL = newURL
+        fetchFeed()
     }
     
     /// 指定されたURLをデフォルトブラウザで開く

--- a/QuickFeed/SettingsView.swift
+++ b/QuickFeed/SettingsView.swift
@@ -90,12 +90,7 @@ struct SettingsView: View {
         }
         
         feedManager.updateFeedURL(tempFeedURL)
-        alertMessage = "設定を保存しました"
-        showingAlert = true
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            dismiss()
-        }
+        dismiss()
     }
 }
 

--- a/QuickFeed/SettingsView.swift
+++ b/QuickFeed/SettingsView.swift
@@ -1,0 +1,105 @@
+//
+//  SettingsView.swift
+//  QuickFeed
+//
+//  Created by sora on 2025/06/27.
+//
+
+import SwiftUI
+
+/// アプリ設定画面のビュー
+struct SettingsView: View {
+    @EnvironmentObject var feedManager: RSSFeedManager
+    @State private var tempFeedURL: String = ""
+    @State private var showingAlert = false
+    @State private var alertMessage = ""
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // ヘッダー
+            HStack {
+                Image(systemName: "gearshape.fill")
+                    .foregroundColor(.orange)
+                    .font(.title2)
+                Text("設定")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Spacer()
+            }
+            .padding(.horizontal)
+            
+            // RSS URL設定
+            VStack(alignment: .leading, spacing: 8) {
+                Text("RSS フィード URL")
+                    .font(.headline)
+                
+                TextField("RSS URL を入力", text: $tempFeedURL)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .font(.system(size: 13, design: .monospaced))
+                
+                Text("デフォルト: https://softantenna.com/folders/feed.rss")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal)
+            
+            // ボタン
+            HStack(spacing: 12) {
+                Button("キャンセル") {
+                    dismiss()
+                }
+                .keyboardShortcut(.escape)
+                
+                Button("デフォルトに戻す") {
+                    tempFeedURL = "https://softantenna.com/folders/feed.rss"
+                }
+                
+                Button("保存") {
+                    saveFeedURL()
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+            }
+            .padding(.horizontal)
+            
+            Spacer()
+        }
+        .frame(width: 400, height: 200)
+        .onAppear {
+            tempFeedURL = feedManager.feedURL
+        }
+        .alert("設定", isPresented: $showingAlert) {
+            Button("OK") { }
+        } message: {
+            Text(alertMessage)
+        }
+    }
+    
+    private func saveFeedURL() {
+        guard !tempFeedURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            alertMessage = "URLを入力してください"
+            showingAlert = true
+            return
+        }
+        
+        guard URL(string: tempFeedURL) != nil else {
+            alertMessage = "無効なURLです"
+            showingAlert = true
+            return
+        }
+        
+        feedManager.updateFeedURL(tempFeedURL)
+        alertMessage = "設定を保存しました"
+        showingAlert = true
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            dismiss()
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environmentObject(RSSFeedManager())
+}

--- a/QuickFeedTests/QuickFeedTests.swift
+++ b/QuickFeedTests/QuickFeedTests.swift
@@ -6,11 +6,45 @@
 //
 
 import Testing
+import Foundation
+@testable import QuickFeed
 
+@MainActor
 struct QuickFeedTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func testDefaultFeedURL() async throws {
+        let feedManager = RSSFeedManager()
+        let defaultURL = "https://softantenna.com/folders/feed.rss"
+        
+        #expect(feedManager.feedURL == defaultURL)
+    }
+    
+    @Test func testFeedURLPersistence() async throws {
+        let feedManager = RSSFeedManager()
+        let testURL = "https://example.com/test.rss"
+        
+        feedManager.feedURL = testURL
+        #expect(feedManager.feedURL == testURL)
+        
+        #expect(UserDefaults.standard.string(forKey: "RSSFeedURL") == testURL)
+    }
+    
+    @Test func testUpdateFeedURL() async throws {
+        let feedManager = RSSFeedManager()
+        let newURL = "https://example.com/new-feed.rss"
+        
+        feedManager.updateFeedURL(newURL)
+        #expect(feedManager.feedURL == newURL)
+    }
+    
+    @Test func testFeedURLFromUserDefaults() async throws {
+        let testURL = "https://example.com/stored.rss"
+        UserDefaults.standard.set(testURL, forKey: "RSSFeedURL")
+        
+        let feedManager = RSSFeedManager()
+        #expect(feedManager.feedURL == testURL)
+        
+        UserDefaults.standard.removeObject(forKey: "RSSFeedURL")
     }
 
 }


### PR DESCRIPTION
## 概要 / Summary

- Add: RSS フィード URL の設定画面を追加
- Add: UserDefaults による URL 永続化機能
- Add: メニューバーからの設定画面アクセス
- Update: RSSFeedManager で設定可能な URL 管理

## Issueリンク / Related Issue

Closes #1

## チェックリスト / Checklist

- [x] 動作確認済み（ローカル or Staging）
- [x] テストケースを追加・更新した
- [x] ドキュメントを更新した（必要があれば）
- [x] AI（Claude等）により生成されたコードの動作確認を行った

## コメント / Notes

- Claude Codeにより `QuickFeed/SettingsView.swift` を生成
- `RSSFeedManager.swift` で UserDefaults による URL 永続化を実装
- `MenuView.swift` に設定ボタンとシート表示機能を追加
- 包括的なテストケースを `QuickFeedTests.swift` に追加
- 初期値は現在の URL (https://softantenna.com/folders/feed.rss) を維持
- 設定した URL は次回起動時も維持される

🤖 Generated with [Claude Code](https://claude.ai/code)